### PR TITLE
cicd: Drop customer managed key

### DIFF
--- a/components/cicd.yaml
+++ b/components/cicd.yaml
@@ -20,7 +20,6 @@ Resources:
   DroneSecret:
     Type: AWS::SecretsManager::Secret
     Properties:
-      KmsKeyId: !Ref Key
       Name: !Sub /${Environment}/cicd/drone
       SecretString: !Sub '{"AccessKeyId": "${DroneAccessKey}", "SecretAccessKey": "${DroneAccessKey.SecretAccessKey}"}'
 
@@ -30,18 +29,3 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AdministratorAccess
       UserName: !Sub ${AWS::Region}.${Environment}.cicd.drone
-
-  Key:
-    Type: AWS::KMS::Key
-    Properties:
-      Description: !Sub CI/CD (${Environment})
-      EnableKeyRotation: true
-      KeyPolicy:
-        Statement:
-          - Action: kms:*
-            Effect: Allow
-            Principal:
-              AWS: !Ref AWS::AccountId
-            Resource: '*'
-            Sid: Allow access for Key Administrators
-        Version: '2012-10-17'


### PR DESCRIPTION
The AWS managed key is free and sufficient for a single-account setup.